### PR TITLE
docs: consume DelEx readiness and reusable asset model

### DIFF
--- a/START-HERE.md
+++ b/START-HERE.md
@@ -1,0 +1,23 @@
+# START HERE — DelEx InnerSource
+
+This repository consumes the upstream DelEx model for reusable asset promotion, readiness, and maintainership.
+
+## Read in this order
+
+1. `docs/README.md`
+2. `docs/service-contribution-model.md`
+3. `docs/repo-readiness-standard.md`
+4. `docs/maintainer-role-map.md`
+
+## Important rule
+
+Reusable assets should stay tied to:
+- source engagement lineage
+- evidence of reuse value
+- gated promotion status
+- upstream DelEx roles and control boundaries
+
+## Upstream dependencies
+
+- `delivery-excellence` for canon and shared object model
+- `delivery-excellence-automation` for schemas and validation

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,18 @@
+# DelEx InnerSource Consumption Layer
+
+This repo should translate the upstream DelEx operating model into contributor readiness, reusable asset promotion, and maintainership flows.
+
+## Upstream sources of truth
+
+- `SocioProphet/delivery-excellence` for prose canon, shared object model, gates, and governance method
+- `SocioProphet/delivery-excellence-automation` for schemas, examples, and contract validation
+
+## Primary docs here
+
+1. [Service Contribution Model](service-contribution-model.md)
+2. [Repo Readiness Standard](repo-readiness-standard.md)
+3. [Maintainer Role Map](maintainer-role-map.md)
+
+## Design rule
+
+This repo should promote reusable service assets and contribution standards using upstream DelEx objects rather than local-only conventions.

--- a/docs/maintainer-role-map.md
+++ b/docs/maintainer-role-map.md
@@ -1,0 +1,48 @@
+# Maintainer Role Map
+
+## Purpose
+
+This repo should map InnerSource roles onto the DelEx governance model so contribution and promotion do not bypass delivery controls.
+
+## Functional mapping
+
+### Maintainer
+Closest DelEx role alignment:
+- reviewer
+- publisher
+
+Responsibilities:
+- review contribution quality
+- maintain documentation and readiness state
+- ensure evidence links remain intact
+
+### Trusted Committer
+Closest DelEx role alignment:
+- reviewer
+- custodian
+
+Responsibilities:
+- implement approved asset changes
+- maintain operational integrity of reusable assets
+
+### Guidance Group / Steering Group
+Closest DelEx role alignment:
+- approver
+- gatekeeper
+
+Responsibilities:
+- approve promotion to reusable/approved state
+- reject promotion without evidence
+- align asset direction with platform method
+
+### Auditor / Assurance participant
+Closest DelEx role alignment:
+- auditor
+
+Responsibilities:
+- verify evidence completeness
+- verify traceability back to engagements or gate decisions
+
+## Practical rule
+
+A maintainer role in this repo should never imply authority to widen action classes, bypass gate requirements, or declare reuse value without evidence. Those remain DelEx-governed decisions.

--- a/docs/repo-readiness-standard.md
+++ b/docs/repo-readiness-standard.md
@@ -1,0 +1,35 @@
+# Repo Readiness Standard
+
+## Purpose
+
+A repo or asset collection is not InnerSource-ready merely because it is visible. It should meet a minimum readiness bar for governed reuse.
+
+## Minimum readiness checks
+
+### Governance and ownership
+- owning group named
+- maintainer or approver named
+- readiness status declared
+- linked upstream DelEx objects identified where relevant
+
+### Evidence and traceability
+- source engagement(s) recorded
+- evidence of reuse value recorded
+- relevant ADRs, PRs, dashboards, or runbooks linked
+
+### Documentation
+- purpose and intended reuse stated
+- contribution expectations stated
+- operational or security notes stated when applicable
+
+### Lifecycle
+- draft / review / approved / retired state is visible
+- promotion and retirement criteria are visible
+
+## Promotion rule
+
+An asset should not be marked approved for reuse unless evidence exists that it solves a recurring need beyond a single engagement.
+
+## Alignment rule
+
+Where upstream DelEx schemas exist, readiness should reference those objects rather than invent local substitutes.

--- a/docs/service-contribution-model.md
+++ b/docs/service-contribution-model.md
@@ -1,0 +1,46 @@
+# Service Contribution Model
+
+## Purpose
+
+InnerSource in this context is not just open contribution to code. It is structured contribution to reusable governed service assets.
+
+## Objects this repo should consume
+
+### Reusable Asset
+Primary unit of contribution and promotion.
+
+Examples:
+- playbooks
+- templates
+- schemas
+- automation components
+- training assets
+
+### Delivery Gate
+Promotion and reuse should be gated, not purely informal.
+
+Examples:
+- draft
+- review
+- approved
+- retired
+
+### Board Item
+Work that improves or operationalizes a reusable asset should remain visible in portfolio and delivery systems.
+
+### Engagement lineage
+A reusable asset should retain traceability to source engagement(s) that proved its value.
+
+## Contribution flow
+
+1. asset emerges from one or more engagements
+2. evidence of reuse value is captured
+3. owner group proposes promotion
+4. reviewers check readiness, documentation, and evidence
+5. asset is approved, retained as draft, or retired
+
+## Anti-patterns
+
+Do not promote an asset because it feels useful.
+Do not treat ad hoc internal notes as reusable patterns without evidence.
+Do not sever the link between an asset and the engagement(s) that justified it.


### PR DESCRIPTION
## Summary

Map the stabilized DelEx readiness and reusable-asset model into `delivery-excellence-innersource` so contribution and promotion flows consume upstream governance rather than local-only conventions.

## Adds

- docs index for innersource as a DelEx consumption layer
- service contribution model
- repo readiness standard
- maintainer role map aligned to DelEx roles

## Why

`delivery-excellence` now defines the shared object model and `delivery-excellence-automation` now validates reusable assets, gate reviews, and related objects. `delivery-excellence-innersource` should consume that model to govern how assets are promoted, reused, and maintained.

## Follow-up

- align readiness linter work to the upstream reusable-asset and gate semantics
- connect maintainer / approver flows to the DelEx role model
